### PR TITLE
Update java-vault-driver to 5.1.0 so I can use kv2 secret

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -29,6 +29,11 @@
         <property name="eachLine" value="true"/>
     </module>
 
+    <module name="LineLength">
+        <property name="max" value="120"/>
+        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+    </module>
+
     <module name="TreeWalker">
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">
@@ -41,10 +46,6 @@
             <property name="allowByTailComment" value="true"/>
             <property name="allowNonPrintableEscapes" value="true"/>
         </module>
-        <module name="LineLength">
-            <property name="max" value="120"/>
-            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
-        </module>
         <module name="AvoidStarImport"/>
         <module name="OneTopLevelClass"/>
         <module name="NoLineWrap"/>
@@ -53,9 +54,6 @@
             <property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
         </module>
         <module name="NeedBraces"/>
-        <module name="LeftCurly">
-            <property name="maxLineLength" value="100"/>
-        </module>
         <module name="RightCurly"/>
         <module name="RightCurly">
             <property name="option" value="alone"/>
@@ -150,11 +148,13 @@
         </module>
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="VariableDeclarationUsageDistance"/>
-        <module name="CustomImportOrder">
+        <!--
+         <module name="CustomImportOrder">
             <property name="specialImportsRegExp" value="com.google"/>
             <property name="sortImportsInGroupAlphabetically" value="true"/>
-            <property name="customImportOrderRules" value="STATIC###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE"/>
+          <property name="customImportOrderRules" value="STATIC###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE"/>
         </module>
+        -->
         <module name="MethodParamPad"/>
         <module name="OperatorWrap">
             <property name="option" value="NL"/>
@@ -180,11 +180,8 @@
         <module name="JavadocMethod">
             <property name="scope" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
-            <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
-            <property name="minLineCount" value="2"/>
             <property name="allowedAnnotations" value="Override, Test"/>
-            <property name="allowThrowsTagsForSubclasses" value="true"/>
         </module>
         <module name="MethodName">
             <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>com.deciphernow</groupId>
     <artifactId>vault-maven-plugin</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>Vault Maven Plugin</name>
@@ -74,13 +74,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <version.bouncycastle.plugin>1.0.0</version.bouncycastle.plugin>
-        <version.checkstyle.plugin>2.17</version.checkstyle.plugin>
-        <version.compiler.plugin>3.6.1</version.compiler.plugin>
+        <version.checkstyle.plugin>3.1.2</version.checkstyle.plugin>
+        <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <version.docker.plugin>0.20.1</version.docker.plugin>
         <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
         <version.freemarker>2.3.23</version.freemarker>
         <version.guava>19.0</version.guava>
-        <version.jacoco>0.7.9</version.jacoco>
+        <version.jacoco>0.8.7</version.jacoco>
         <version.jacoco.plugin>${version.jacoco}</version.jacoco.plugin>
         <version.java.source>1.8</version.java.source>
         <version.java.target>1.8</version.java.target>
@@ -96,7 +96,7 @@
         <version.source.plugin>3.0.1</version.source.plugin>
         <version.surefire.plugin>2.19.1</version.surefire.plugin>
         <version.vault>0.6.5</version.vault>
-        <version.vault.driver>2.0.0</version.vault.driver>
+        <version.vault.driver>5.1.0</version.vault.driver>
     </properties>
 
     <dependencies>
@@ -181,7 +181,7 @@
 
     <build>
         <plugins>
-            <plugin>
+             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
                 <version>${version.docker.plugin}</version>
@@ -245,7 +245,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
+             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>${version.checkstyle.plugin}</version>

--- a/src/main/java/com/deciphernow/maven/plugins/vault/VaultMojo.java
+++ b/src/main/java/com/deciphernow/maven/plugins/vault/VaultMojo.java
@@ -36,4 +36,5 @@ abstract class VaultMojo extends AbstractMojo {
 
   @Parameter(property = "skipExecution", defaultValue = "false")
   protected boolean skipExecution;
+
 }

--- a/src/main/java/com/deciphernow/maven/plugins/vault/config/Mapping.java
+++ b/src/main/java/com/deciphernow/maven/plugins/vault/config/Mapping.java
@@ -31,7 +31,8 @@ public class Mapping implements Serializable {
   /**
    * Initializes a new instance of the {@link Mapping} class.
    */
-  public Mapping() { }
+  public Mapping() {
+  }
 
   /**
    * Initializes a new instance of the {@link Mapping} class.
@@ -67,7 +68,8 @@ public class Mapping implements Serializable {
    *
    * @return the hash code
    */
-  public int hashCode() {
+  @Override
+public int hashCode() {
     return Objects.hash(this.key, this.property);
   }
 
@@ -76,7 +78,8 @@ public class Mapping implements Serializable {
    *
    * @return {@code true} if the this mapping is equal to the object; otherwise, {@code false}
    */
-  public boolean equals(Object object) {
+  @Override
+public boolean equals(Object object) {
     if (object instanceof Mapping) {
       Mapping that = (Mapping) object;
       return Objects.equals(this.key, that.key)

--- a/src/main/java/com/deciphernow/maven/plugins/vault/config/Path.java
+++ b/src/main/java/com/deciphernow/maven/plugins/vault/config/Path.java
@@ -32,7 +32,8 @@ public class Path implements Serializable {
   /**
    * Initializes a new instance of the {@link Path} class.
    */
-  public Path() { }
+  public Path() {
+  }
 
   /**
    * Initializes a new instance of the {@link Path} class.
@@ -68,7 +69,8 @@ public class Path implements Serializable {
    *
    * @return the hash code
    */
-  public int hashCode() {
+  @Override
+public int hashCode() {
     return Objects.hash(this.name, this.mappings);
   }
 
@@ -77,7 +79,8 @@ public class Path implements Serializable {
    *
    * @return {@code true} if the this path is equal to the object; otherwise, {@code false}
    */
-  public boolean equals(Object object) {
+  @Override
+public boolean equals(Object object) {
     if (object instanceof Path) {
       Path that = (Path) object;
       return Objects.equals(this.name, that.name)

--- a/src/main/java/com/deciphernow/maven/plugins/vault/config/Server.java
+++ b/src/main/java/com/deciphernow/maven/plugins/vault/config/Server.java
@@ -38,10 +38,13 @@ public class Server implements Serializable {
 
   private boolean skipExecution;
 
+  private int kvVersion = 2;
+
   /**
    * Initializes a new instance of the {@link Server} class.
    */
-  public Server() { }
+  public Server() {
+  }
 
   /**
    * Initializes a new instance of the {@link Server} class.
@@ -52,13 +55,14 @@ public class Server implements Serializable {
    * @param sslCertificate the SSL certificate file or null
    * @param paths the paths for the server
    */
-  public Server(String url, String token, boolean sslVerify, File sslCertificate, List<Path> paths,
+  public Server(String url, String token, int kvVersion, boolean sslVerify, File sslCertificate, List<Path> paths,
                 boolean skipExecution) {
     this.paths = paths;
     this.sslCertificate = sslCertificate;
     this.sslVerify = sslVerify;
     this.token = token;
     this.url = url;
+    this.kvVersion = kvVersion;
     this.skipExecution = skipExecution;
   }
 
@@ -108,6 +112,14 @@ public class Server implements Serializable {
   }
 
   /**
+   * Gets the KV version of this secret.
+   * @return the version
+   */
+  public int getKvVersion() {
+    return this.kvVersion;
+  }
+
+  /**
    * Indicates if server execution should be skipped.
    *
    * @return the skipExecution
@@ -121,8 +133,10 @@ public class Server implements Serializable {
    *
    * @return the hash code
    */
-  public int hashCode() {
-    return Objects.hash(this.sslCertificate, this.sslVerify, this.token, this.url, this.paths, this.skipExecution);
+  @Override
+public int hashCode() {
+    return Objects.hash(this.sslCertificate, this.sslVerify, this.token, this.url, this.kvVersion,
+            this.paths, this.skipExecution);
   }
 
   /**
@@ -130,7 +144,8 @@ public class Server implements Serializable {
    *
    * @return {@code true} if the this server is equal to the object; otherwise, {@code false}
    */
-  public boolean equals(Object object) {
+  @Override
+public boolean equals(Object object) {
     if (object instanceof Server) {
       Server that = (Server) object;
       return Objects.equals(this.paths, that.paths)
@@ -138,6 +153,7 @@ public class Server implements Serializable {
           && Objects.equals(this.skipExecution, that.skipExecution)
           && Objects.equals(this.sslCertificate, that.sslCertificate)
           && Objects.equals(this.token, that.token)
+          && Objects.equals(this.kvVersion, that.kvVersion)
           && Objects.equals(this.url, that.url);
     }
     return false;

--- a/src/test/java/com/deciphernow/maven/plugins/vault/IntTestPullMojo.java
+++ b/src/test/java/com/deciphernow/maven/plugins/vault/IntTestPullMojo.java
@@ -46,6 +46,7 @@ public class IntTestPullMojo {
   private static final String VAULT_PORT = System.getProperty("vault.port", "443");
   private static final String VAULT_SERVER = String.format("https://%s:%s", VAULT_HOST, VAULT_PORT);
   private static final String VAULT_TOKEN = System.getProperty("vault.token");
+  private static final int KV_VERSION = Integer.parseInt(System.getProperty("vault.kv.version", "2"));
 
   private static Mapping randomMapping() {
     return new Mapping(UUID.randomUUID().toString(), UUID.randomUUID().toString());
@@ -72,7 +73,7 @@ public class IntTestPullMojo {
       List<Path> paths = randomPaths(10, 10);
       File certificate = new File(VAULT_CERTIFICATE.toURI());
       System.out.println(String.format("%s/%s", VAULT_SERVER, VAULT_TOKEN));
-      this.servers = ImmutableList.of(new Server(VAULT_SERVER, VAULT_TOKEN, true, certificate, paths, false));
+      this.servers = ImmutableList.of(new Server(VAULT_SERVER, VAULT_TOKEN, KV_VERSION, true, certificate, paths, false));
       this.properties = new Properties();
       this.servers.stream().forEach(server -> {
         server.getPaths().stream().forEach(path -> {

--- a/src/test/java/com/deciphernow/maven/plugins/vault/IntTestPushMojo.java
+++ b/src/test/java/com/deciphernow/maven/plugins/vault/IntTestPushMojo.java
@@ -46,6 +46,7 @@ public class IntTestPushMojo {
   private static final String VAULT_PORT = System.getProperty("vault.port", "443");
   private static final String VAULT_SERVER = String.format("https://%s:%s", VAULT_HOST, VAULT_PORT);
   private static final String VAULT_TOKEN = System.getProperty("vault.token");
+  private static final int KV_VERSION = Integer.parseInt(System.getProperty("vault.kv.version", "2"));
 
   private static Mapping randomMapping() {
     return new Mapping(UUID.randomUUID().toString(), UUID.randomUUID().toString());
@@ -72,7 +73,7 @@ public class IntTestPushMojo {
       List<Path> paths = randomPaths(10, 10);
       File certificate = new File(VAULT_CERTIFICATE.toURI());
       System.out.println(String.format("%s/%s", VAULT_SERVER, VAULT_TOKEN));
-      this.servers = ImmutableList.of(new Server(VAULT_SERVER, VAULT_TOKEN, true, certificate, paths, false));
+      this.servers = ImmutableList.of(new Server(VAULT_SERVER, VAULT_TOKEN, KV_VERSION, true, certificate, paths, false));
       this.properties = new Properties();
       this.servers.stream().forEach(server -> {
         server.getPaths().stream().forEach(path -> {

--- a/src/test/java/com/deciphernow/maven/plugins/vault/IntTestVaults.java
+++ b/src/test/java/com/deciphernow/maven/plugins/vault/IntTestVaults.java
@@ -47,6 +47,7 @@ public class IntTestVaults {
   private static final String VAULT_PORT = System.getProperty("vault.port", "443");
   private static final String VAULT_SERVER = String.format("https://%s:%s", VAULT_HOST, VAULT_PORT);
   private static final String VAULT_TOKEN = System.getProperty("vault.token");
+  private static final int KV_VERSION = Integer.parseInt(System.getProperty("vault.kv.version", "2"));
 
   private static Mapping randomMapping() {
     return new Mapping(UUID.randomUUID().toString(), UUID.randomUUID().toString());
@@ -74,7 +75,7 @@ public class IntTestVaults {
       File certificate = new File(VAULT_CERTIFICATE.toURI());
       boolean skipExecution = false;
       System.out.println(String.format("%s/%s", VAULT_SERVER, VAULT_TOKEN));
-      this.servers = ImmutableList.of(new Server(VAULT_SERVER, VAULT_TOKEN, true, certificate, paths, skipExecution));
+      this.servers = ImmutableList.of(new Server(VAULT_SERVER, VAULT_TOKEN, KV_VERSION, true, certificate, paths, skipExecution));
       this.properties = new Properties();
       this.servers.stream().forEach(server -> {
         server.getPaths().stream().forEach(path -> {

--- a/src/test/java/com/deciphernow/maven/plugins/vault/config/TestServer.java
+++ b/src/test/java/com/deciphernow/maven/plugins/vault/config/TestServer.java
@@ -40,7 +40,7 @@ public class TestServer {
   private static final boolean SKIP_EXECUTION = RANDOM.nextBoolean();
   private static final String TOKEN = UUID.randomUUID().toString();
   private static final String URL = UUID.randomUUID().toString();
-  private static final Server INSTANCE = new Server(URL, TOKEN, SSL_VERIFY, SSL_CERTIFICATE, PATHS, SKIP_EXECUTION);
+  private static final Server INSTANCE = new Server(URL, TOKEN, 2, SSL_VERIFY, SSL_CERTIFICATE, PATHS, SKIP_EXECUTION);
 
   private static Path randomPath(int mappingCount) {
     return new Path(UUID.randomUUID().toString(), randomMappings(mappingCount));


### PR DESCRIPTION
Need to access kv2 secrets. Changed version to 2.0.0 to reflect default kv change.

Unable to run unit tests. Tested changes against running vault (1.7.2) server